### PR TITLE
centered login and signup

### DIFF
--- a/public/stylesheets/loginForm.css
+++ b/public/stylesheets/loginForm.css
@@ -4,12 +4,15 @@
   margin-top: 10%;
   align-items: center;
   grid-row: 2;
+  grid-column: 2;
+  justify-self: center;
   background-color: transparent;
 }
 
 .loginPageWrapper{
   display: grid;
   grid-template-rows: 80px 1fr;
+  grid-template-columns: 200px 1fr;
   height: 100%;
 }
 

--- a/public/stylesheets/signUp-Form.css
+++ b/public/stylesheets/signUp-Form.css
@@ -4,11 +4,14 @@
   margin-top: 10%;
   align-items: center;
   grid-row: 2;
+  grid-column: 2;
+  justify-self: center;
 }
 
 .signUpPageWrapper{
   display: grid;
   grid-template-rows: 80px 1fr;
+  grid-template-columns: 200px 1fr;
 }
 
 .form-label{
@@ -85,5 +88,3 @@
 .alert{
   border: 3px ridge darkred;
 }
-
-  

--- a/public/stylesheets/users-page.css
+++ b/public/stylesheets/users-page.css
@@ -45,8 +45,9 @@
     flex-flow: wrap;
     grid-row: 2;
     grid-column: 2;
-    justify-content: center;
+    justify-content: start;
     width: 1200px;
+    padding-left: 50px;
 }
 
 .users-h2{


### PR DESCRIPTION
i created columns for both the login and sign up pages then centered the forms to their columns so they should stay centered on different screen sizes.  They also won't cover the side bar anymore if the screen gets too small.  I also changed the users page so that it displays the names from the start instead of the center.